### PR TITLE
Add cpu usage collector for macos

### DIFF
--- a/Sources/SysMonitor/MetricCollecting.swift
+++ b/Sources/SysMonitor/MetricCollecting.swift
@@ -6,8 +6,49 @@ protocol CpuMetricCollecting {
     func collect() -> Double
 }
 
+import Darwin
+
 class CpuMetricCollector: CpuMetricCollecting {
+    private var previousCPUTicks: host_cpu_load_info?
+
     func collect() -> Double {
-        .zero
+        cpuUsage()
+    }
+
+    private func cpuUsage() -> Double {
+        var cpuLoadInfo = host_cpu_load_info()
+        var count = mach_msg_type_number_t(MemoryLayout<host_cpu_load_info>.size / MemoryLayout<integer_t>.size) 
+
+        let result = withUnsafeMutablePointer(to: &cpuLoadInfo) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO, $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            print("Error getting cpu usage")
+            return .zero
+        }
+
+        let user = Double(cpuLoadInfo.cpu_ticks.0)
+        let system = Double(cpuLoadInfo.cpu_ticks.1)
+        let idle = Double(cpuLoadInfo.cpu_ticks.2)
+        let nice = Double(cpuLoadInfo.cpu_ticks.3)
+
+        guard let previousCPUTicks else {
+            previousCPUTicks = cpuLoadInfo
+            return .zero
+        }
+
+        // Diffs
+        let userDiff = user - Double(previousCPUTicks.cpu_ticks.0)
+        let systemDiff = system - Double(previousCPUTicks.cpu_ticks.1)
+        let idleDiff  = idle - Double(previousCPUTicks.cpu_ticks.2)
+        let niceDiff = nice - Double(previousCPUTicks.cpu_ticks.3)
+
+        let total = userDiff + systemDiff + idleDiff + niceDiff
+        let used = userDiff + systemDiff + niceDiff
+
+        self.previousCPUTicks = cpuLoadInfo
+        return (used / total) * 100.0
     }
 }

--- a/Sources/SysMonitor/SysMonitor.swift
+++ b/Sources/SysMonitor/SysMonitor.swift
@@ -20,8 +20,8 @@ struct SysMonitor: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Show memory usage")
     var memory = false 
 
-    static func run() throws {
-        let container = resolveContainer()
+    func run() throws {
+        let container = Self.resolveContainer()
         let monitor = container.resolve(SystemMonitorManager.self)
         guard let monitor else {
             throw RuntimeError.failedToResolve


### PR DESCRIPTION
## Why
This change adds a colector to encapsulate collecting and calculating cpu usage, as well as couple of changes to fix run of program

## How
- use host cpu load info to get accurate data from system 
- add print statements for rudimentary feedback
- adjust run function to *not* a static func 
