### PR TITLE
Add memory collector for macos

### DIFF
--- a/Sources/SysMonitor/Collectors/CpuMetricCollector.swift
+++ b/Sources/SysMonitor/Collectors/CpuMetricCollector.swift
@@ -1,11 +1,3 @@
-protocol MetricCollecting {
-    func collect() -> UsagePercentageable
-}
-
-protocol CpuMetricCollecting {
-    func collect() -> Double
-}
-
 import Darwin
 
 class CpuMetricCollector: CpuMetricCollecting {

--- a/Sources/SysMonitor/Collectors/MemMetricCollector.swift
+++ b/Sources/SysMonitor/Collectors/MemMetricCollector.swift
@@ -1,0 +1,35 @@
+import Darwin
+
+class MemMetricCollector: MemoryMetricCollecting {
+    let pageSize = UInt64(vm_kernel_page_size)
+
+    func collect() -> MemoryMetric {
+        memUsage()
+    }
+
+    private func memUsage() -> MemoryMetric {
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(MemoryLayout<vm_statistics64>.size / MemoryLayout<integer_t>.size) 
+
+        let result = withUnsafeMutablePointer(to: &stats) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            print("Error getting memory usage")
+            return .zero
+        }
+
+        let free = UInt64(stats.free_count)
+        let active = UInt64(stats.active_count)
+        let inactive = UInt64(stats.inactive_count)
+        let wired = UInt64(stats.wire_count)
+
+        return MemoryMetric(
+            total: [free, active, inactive, wired].reduce(0, +),
+            used: active,
+            free: free, 
+            cached: wired)
+    }
+}

--- a/Sources/SysMonitor/Collectors/MetricCollecting.swift
+++ b/Sources/SysMonitor/Collectors/MetricCollecting.swift
@@ -7,6 +7,6 @@ protocol CpuMetricCollecting {
 }
 
 protocol MemoryMetricCollecting {
-    func collect() -> Double
+    func collect() -> MemoryMetric
 }
 

--- a/Sources/SysMonitor/Collectors/MetricCollecting.swift
+++ b/Sources/SysMonitor/Collectors/MetricCollecting.swift
@@ -1,0 +1,12 @@
+protocol MetricCollecting {
+    func collect() -> UsagePercentageable
+}
+
+protocol CpuMetricCollecting {
+    func collect() -> Double
+}
+
+protocol MemoryMetricCollecting {
+    func collect() -> Double
+}
+

--- a/Sources/SysMonitor/SysMonitor.swift
+++ b/Sources/SysMonitor/SysMonitor.swift
@@ -36,8 +36,15 @@ struct SysMonitor: ParsableCommand {
             CpuMetricCollector()
         }
 
+        container.register(MemMetricCollector.self) { _ in
+            MemMetricCollector()
+        }
+
         container.register(SystemMonitorManager.self) { resolver in
-            SystemMonitorManager(cpuCollector: resolver.resolve(CpuMetricCollector.self)!)
+            SystemMonitorManager(
+                cpuCollector: resolver.resolve(CpuMetricCollector.self)!,
+                memCollector: resolver.resolve(MemMetricCollector.self)!
+            )
         }
 
         return container

--- a/Sources/SysMonitor/SystemMonitorManager.swift
+++ b/Sources/SysMonitor/SystemMonitorManager.swift
@@ -14,10 +14,15 @@ final class SystemMonitorManager {
     }
     private var isRunning = false 
     private var cpuMetricCollector: CpuMetricCollecting
+    private var memMetricCollector: MemoryMetricCollecting
     private var timer: Timer?
 
-    init(cpuCollector: CpuMetricCollecting) {
+    init(
+        cpuCollector: CpuMetricCollecting,
+        memCollector: MemoryMetricCollecting
+    ) {
         cpuMetricCollector = cpuCollector
+        memMetricCollector = memCollector
     }
 
     func startMonitoring(with interval: TimeInterval = 1.0) {

--- a/Sources/SysMonitor/SystemMonitorManager.swift
+++ b/Sources/SysMonitor/SystemMonitorManager.swift
@@ -7,7 +7,8 @@ final class SystemMonitorManager {
                 """
                 =====
                 SysMetrics: 
-                - CPU Usage: \(metrics.last?.cpuUsage ?? Double.zero)
+                - CPU usage: \(metrics.last?.cpuUsage ?? .zero)
+                - Memory usage:  \(metrics.last?.memoryUsage.usagePercentage ?? .zero)
     """
             )
         }
@@ -48,7 +49,7 @@ final class SystemMonitorManager {
         let metrics = SystemMetric(
             timestamp: Date(),
             cpuUsage: cpuMetricCollector.collect(),
-            memoryUsage:.zero,
+            memoryUsage: memMetricCollector.collect(),
             diskUsage: .zero,
             networkUsage: .zero
         )


### PR DESCRIPTION
## Why
To implement memory usage data collection

## How
- Changed memory collection protocol to return MemoryMetric struct
- Implemented collecting data 
- Added collector to system monitor manager
