### PR TITLE
Add network usage collector for macos

### DIFF
--- a/Sources/SysMonitor/Collectors/MetricCollecting.swift
+++ b/Sources/SysMonitor/Collectors/MetricCollecting.swift
@@ -14,3 +14,7 @@ protocol MemoryMetricCollecting {
 protocol DiskMetricCollecting {
     func collect() -> DiskMetric
 }
+
+protocol NetworkMetricCollecting {
+    func collect() -> NetworkMetric
+}

--- a/Sources/SysMonitor/Collectors/NetworkMetricCollector.swift
+++ b/Sources/SysMonitor/Collectors/NetworkMetricCollector.swift
@@ -1,0 +1,60 @@
+import Darwin
+
+class NetworkMetricCollector: NetworkMetricCollecting {
+    func collect() -> NetworkMetric {
+        networkUsage()
+    }
+
+    private func networkUsage() -> NetworkMetric {
+        var mib = [CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST2, 0]
+
+        var len: size_t = 0
+        guard sysctl(&mib, 6, nil, &len, nil, 0) == 0 else {
+            return .zero
+        }
+
+        var buffer = [UInt8](repeating: 0, count: len)
+        guard sysctl(&mib, 6, &buffer, &len, nil, 0) == 0 else {
+            return .zero
+        }
+
+        var interfaces: [NetworkMetric] = []
+        var offset = 0
+
+        while offset < len {
+            let data = buffer.dropFirst(offset)
+
+            guard let msgPtr = data.withUnsafeBytes({ pointer in
+                pointer.baseAddress?.assumingMemoryBound(to: if_msghdr.self)
+            }) else {
+                return .zero
+            }
+
+            if msgPtr.pointee.ifm_type == RTM_IFINFO2 {
+                guard let ifmPtr = data.withUnsafeBytes({ pointer in
+                    pointer.baseAddress?.assumingMemoryBound(to: if_msghdr2.self)
+                }) else { return .zero }
+
+                let namePtr = data.dropFirst(MemoryLayout<if_msghdr2>.size).withUnsafeBytes { ptr -> UnsafePointer<CChar>? in
+                    ptr.baseAddress?.assumingMemoryBound(to: CChar.self)
+                }
+
+                let interfaceName = namePtr.map { String(cString: $0) } ?? "unknown"
+
+                let metric = NetworkMetric(
+                    name: interfaceName,
+                    bytesReceived: UInt64(ifmPtr.pointee.ifm_data.ifi_ibytes),
+                    bytesSent: UInt64(ifmPtr.pointee.ifm_data.ifi_obytes),
+                    packetsReceived: UInt64(ifmPtr.pointee.ifm_data.ifi_ipackets),
+                    packetsSent: UInt64(ifmPtr.pointee.ifm_data.ifi_opackets)
+                )
+
+                interfaces.append(metric)
+            }
+
+            offset += Int(msgPtr.pointee.ifm_msglen)
+        }
+
+        return interfaces.reduce(.zero, +) 
+    }
+}

--- a/Sources/SysMonitor/Model/NetworkMetric.swift
+++ b/Sources/SysMonitor/Model/NetworkMetric.swift
@@ -1,12 +1,47 @@
 import Foundation
 
 struct NetworkMetric {
+    let name: String?
     let bytesReceived: UInt64
     let bytesSent: UInt64
     let packetsReceived: UInt64
     let packetsSent: UInt64
 
+init(name: String? = nil, bytesReceived: UInt64, bytesSent: UInt64, packetsReceived: UInt64, packetsSent: UInt64) {
+        self.name = name
+        self.bytesReceived = bytesReceived
+        self.bytesSent = bytesSent
+        self.packetsReceived = packetsReceived
+        self.packetsSent = packetsSent
+    }
+}
+
+extension NetworkMetric: AdditiveArithmetic {
     static var zero: NetworkMetric {
         NetworkMetric(bytesReceived: .zero, bytesSent: .zero, packetsReceived: .zero, packetsSent: .zero)
+    }
+
+    static func +(lhs: NetworkMetric, rhs: NetworkMetric) -> NetworkMetric {
+        return NetworkMetric(
+            bytesReceived: lhs.bytesReceived + rhs.bytesReceived,
+            bytesSent: lhs.bytesSent + rhs.bytesSent,
+            packetsReceived: lhs.packetsReceived + rhs.packetsReceived,
+            packetsSent: lhs.packetsSent + lhs.packetsSent
+        )
+    }
+
+    static func -(lhs: NetworkMetric, rhs: NetworkMetric) -> NetworkMetric {
+        return NetworkMetric(
+            bytesReceived: lhs.bytesReceived.safeSubtract(rhs.bytesReceived),
+            bytesSent: lhs.bytesSent.safeSubtract(rhs.bytesSent),
+            packetsReceived: lhs.packetsReceived.safeSubtract(rhs.packetsReceived),
+            packetsSent: lhs.packetsSent.safeSubtract(rhs.packetsSent)
+        )
+    }
+}
+
+extension UInt64 {
+    func safeSubtract(_ subtrahend: UInt64) -> UInt64 {
+        self >= subtrahend ? self - subtrahend : .zero
     }
 }

--- a/Sources/SysMonitor/SysMonitor.swift
+++ b/Sources/SysMonitor/SysMonitor.swift
@@ -44,11 +44,16 @@ struct SysMonitor: ParsableCommand {
             DiskMetricCollector()
         }
 
+        container.register(NetworkMetricCollector.self) { _ in
+            NetworkMetricCollector()
+        }
+
         container.register(SystemMonitorManager.self) { resolver in
             SystemMonitorManager(
                 cpuCollector: resolver.resolve(CpuMetricCollector.self)!,
                 memCollector: resolver.resolve(MemMetricCollector.self)!,
-                diskCollector: resolver.resolve(DiskMetricCollector.self)!
+                diskCollector: resolver.resolve(DiskMetricCollector.self)!,
+                networkCollector: resolver.resolve(NetworkMetricCollector.self)!
             )
         }
 

--- a/Sources/SysMonitor/SystemMonitorManager.swift
+++ b/Sources/SysMonitor/SystemMonitorManager.swift
@@ -12,6 +12,9 @@ final class SystemMonitorManager {
                 - Disk usage: 
                     - Writes: \(metrics.last?.diskUsage.writeBytes ?? .zero) bytes
                     - Reads: \(metrics.last?.diskUsage.readBytes ?? .zero) bytes
+                - Network usage:
+                    - In: \(metrics.last?.networkUsage.bytesReceived ?? .zero) bytes
+                    - Out: \(metrics.last?.networkUsage.bytesSent ?? .zero) bytes
     """
             )
         }
@@ -20,16 +23,19 @@ final class SystemMonitorManager {
     private var cpuMetricCollector: CpuMetricCollecting
     private var memMetricCollector: MemoryMetricCollecting
     private var diskMetricCollector: DiskMetricCollecting
+    private var networkMetricCollector: NetworkMetricCollecting
     private var timer: Timer?
 
     init(
         cpuCollector: CpuMetricCollecting,
         memCollector: MemoryMetricCollecting,
-        diskCollector: DiskMetricCollecting
+        diskCollector: DiskMetricCollecting,
+        networkCollector: NetworkMetricCollecting
     ) {
         cpuMetricCollector = cpuCollector
         memMetricCollector = memCollector
         diskMetricCollector = diskCollector
+        networkMetricCollector = networkCollector
     }
 
     func startMonitoring(with interval: TimeInterval = 1.0) {
@@ -57,7 +63,7 @@ final class SystemMonitorManager {
             cpuUsage: cpuMetricCollector.collect(),
             memoryUsage: memMetricCollector.collect(),
             diskUsage: diskMetricCollector.collect(),
-            networkUsage: .zero
+            networkUsage: networkMetricCollector.collect()
         )
 
         self.metrics.append(metrics)


### PR DESCRIPTION
# Why: 
This change brings a collector for network metrics.

# How:
- added collecting protocol
- added implementation of network collection using sysctl
- hooked new collector to system monitor manager
